### PR TITLE
Lazy-load lesson content via import.meta.glob, split from main bundle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,9 @@ frontend/src/
     progress.ts        # UserProgress, SRSCard, ExerciseResult, VocabEntry, LessonResult, LessonScore, ReviewSession, ReviewResult
 
   data/
-    curriculum.ts      # Full curriculum structure (10 sections, 38 units)
-    units/unit-01.json # Unit 1 content (exercises + vocabulary arrays)
+    curriculum.ts      # Course structure with LessonMeta (10 sections, 38 units)
+    lessonLoader.ts    # Lazy lesson loader using import.meta.glob
+    units/unit-01/     # Per-lesson JSON files (unit-01-lesson-01.json, etc.)
 ```
 
 ## Key Conventions
@@ -96,7 +97,7 @@ frontend/src/
 
 ## Data Flow
 User Input → React Component → Zustand Store Action → Dexie (IndexedDB)
-Curriculum data is static/bundled. User progress & SRS state are in IndexedDB.
+Curriculum structure is static/bundled. Lesson content is lazy-loaded via `import.meta.glob` (separate chunks). User progress & SRS state are in IndexedDB.
 
 ### Vocabulary Architecture (Anki-style Note/Card separation)
 - **Content (Notes):** `vocabulary` arrays in lesson JSON → seeded to IndexedDB `vocabulary` table on app init via `seedVocabulary()`

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -35,7 +35,7 @@ Uses ts-fsrs with 90% target retention.
 
 ## Lesson Engine (engine/lessonRunner.ts)
 ```ts
-findLesson(lessonId: string): Lesson | undefined
+findLesson(lessonId: string): Promise<Lesson | undefined>  // lazy-loads lesson chunk
 collectTargetWords(exercises: Exercise[]): string[]
 buildLessonResult(lessonId, exercises, results, startTime): LessonResult
 ```
@@ -58,9 +58,10 @@ validateAnswer(userInput: string, correctAnswer: string): ValidationResult
 All store hydration is centralized in `shared/components/HydrationGuard.tsx`, wrapped around routes in `App.tsx`. Individual pages do NOT handle hydration — they can assume stores are ready. Deep-links work correctly.
 
 ## Curriculum Data
-- `data/curriculum.ts` — exports `curriculum: Curriculum` with all sections/units (lessons empty for units 2-38)
-- `data/units/unit-01.json` — full lesson/exercise content for unit 1
-- Curriculum is imported statically, not fetched
+- `data/curriculum.ts` — exports `curriculum: Curriculum` with sections/units and `LessonMeta[]` (lightweight: id, name, order)
+- `data/lessonLoader.ts` — `loadLesson(id)` and `loadAllLessons()` via `import.meta.glob` (lazy chunks)
+- `data/units/unit-01/` — per-lesson JSON files (unit-01-lesson-01.json, etc.)
+- Curriculum structure is bundled; lesson content is lazy-loaded on demand
 
 ## Routing (App.tsx)
 - `/` → `features/path/PathPage.tsx`

--- a/frontend/src/data/curriculum.ts
+++ b/frontend/src/data/curriculum.ts
@@ -1,11 +1,4 @@
-import type { Curriculum, Lesson } from '../types';
-import lesson01 from './units/unit-01/unit-01-lesson-01.json';
-import lesson02 from './units/unit-01/unit-01-lesson-02.json';
-import lesson03 from './units/unit-01/unit-01-lesson-03.json';
-import lesson04 from './units/unit-01/unit-01-lesson-04.json';
-import lesson05 from './units/unit-01/unit-01-lesson-05.json';
-
-const unit01 = [lesson01, lesson02, lesson03, lesson04, lesson05] as unknown as Lesson[];
+import type { Curriculum } from '../types';
 
 export const curriculum: Curriculum = {
   sections: [
@@ -27,7 +20,13 @@ export const curriculum: Curriculum = {
           vocabulary_targets: ['ciao', 'buongiorno', 'come stai', 'grazie', 'per favore'],
           grammar_notes: 'Italian is a phonetic language — each letter is almost always pronounced the same way. Double consonants are held longer. Stress usually falls on the second-to-last syllable.',
           order: 1,
-          lessons: unit01,
+          lessons: [
+            { id: 'unit-01-lesson-01', unit_id: 'unit-01', name: 'Hello & Goodbye', order: 1 },
+            { id: 'unit-01-lesson-02', unit_id: 'unit-01', name: 'Polite Phrases', order: 2 },
+            { id: 'unit-01-lesson-03', unit_id: 'unit-01', name: 'How Are You?', order: 3 },
+            { id: 'unit-01-lesson-04', unit_id: 'unit-01', name: 'Basic Responses', order: 4 },
+            { id: 'unit-01-lesson-05', unit_id: 'unit-01', name: 'Review & Mix', order: 5 },
+          ],
         },
         {
           id: 'unit-02',

--- a/frontend/src/data/lessonLoader.ts
+++ b/frontend/src/data/lessonLoader.ts
@@ -1,0 +1,32 @@
+import type { Lesson } from '../types';
+
+/**
+ * Lazy lesson loader using Vite's import.meta.glob.
+ * Each lesson JSON is a separate chunk — loaded on demand, not bundled upfront.
+ */
+const lessonModules = import.meta.glob<Lesson>(
+  './units/unit-*/unit-*-lesson-*.json',
+  { import: 'default' },
+);
+
+/** Map lesson ID → dynamic import function */
+const importMap = new Map<string, () => Promise<Lesson>>();
+for (const [path, importFn] of Object.entries(lessonModules)) {
+  const match = path.match(/\/(unit-\d+-lesson-\d+)\.json$/);
+  if (match) importMap.set(match[1], importFn);
+}
+
+/** Load a single lesson by ID. Returns undefined if no matching file exists. */
+export async function loadLesson(lessonId: string): Promise<Lesson | undefined> {
+  const importFn = importMap.get(lessonId);
+  if (!importFn) return undefined;
+  return importFn();
+}
+
+/** Load all available lessons (used for vocabulary seeding at app init). */
+export async function loadAllLessons(): Promise<Lesson[]> {
+  const results = await Promise.all(
+    [...importMap.values()].map((fn) => fn()),
+  );
+  return results;
+}

--- a/frontend/src/engine/lessonRunner.ts
+++ b/frontend/src/engine/lessonRunner.ts
@@ -1,17 +1,8 @@
-import type { Exercise, ExerciseResult, Lesson, LessonResult } from '../types';
-import { curriculum } from '../data/curriculum';
+import type { Exercise, ExerciseResult, LessonResult } from '../types';
+import { loadLesson } from '../data/lessonLoader';
 
-/** Find a lesson by ID across all sections/units. */
-export function findLesson(lessonId: string): Lesson | undefined {
-  for (const section of curriculum.sections) {
-    for (const unit of section.units) {
-      for (const lesson of unit.lessons) {
-        if (lesson.id === lessonId) return lesson;
-      }
-    }
-  }
-  return undefined;
-}
+/** Load a lesson by ID (lazy — fetches the lesson chunk on demand). */
+export { loadLesson as findLesson };
 
 /** Collect all unique target words from the exercises. */
 export function collectTargetWords(exercises: Exercise[]): string[] {

--- a/frontend/src/features/lesson/LessonPage.tsx
+++ b/frontend/src/features/lesson/LessonPage.tsx
@@ -1,7 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { findLesson } from '@/engine/lessonRunner';
+import type { Lesson } from '@/types';
 import EmptyState from '@/shared/components/EmptyState';
+import LoadingScreen from '@/shared/components/LoadingScreen';
 import renderExercise from '@/features/exercises/renderExercise';
 import { useLessonState } from './useLessonState';
 import LessonHeader from './LessonHeader';
@@ -11,7 +13,23 @@ import GrammarTip from './GrammarTip';
 export default function LessonPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const lesson = id ? findLesson(id) : undefined;
+  const [lesson, setLesson] = useState<Lesson | undefined | null>(null);
+
+  useEffect(() => {
+    if (!id) {
+      setLesson(undefined);
+      return;
+    }
+    let cancelled = false;
+    findLesson(id).then((result) => {
+      if (!cancelled) setLesson(result);
+    });
+    return () => { cancelled = true; };
+  }, [id]);
+
+  if (lesson === null) {
+    return <LoadingScreen />;
+  }
 
   if (!lesson) {
     return (
@@ -38,7 +56,7 @@ function LessonContent({
   lesson,
   onExit,
 }: {
-  lesson: ReturnType<typeof findLesson> & {};
+  lesson: Lesson;
   onExit: () => void;
 }) {
   const [showExitConfirm, setShowExitConfirm] = useState(false);

--- a/frontend/src/features/path/LessonList.tsx
+++ b/frontend/src/features/path/LessonList.tsx
@@ -1,8 +1,8 @@
 import { Link } from 'react-router-dom';
-import type { Lesson, LessonScore } from '@/types';
+import type { LessonMeta, LessonScore } from '@/types';
 
 interface LessonListProps {
-  lessons: Lesson[];
+  lessons: LessonMeta[];
   completedLessons: string[];
   lessonScores: Record<string, LessonScore>;
   onResetLesson: (lessonId: string) => void;

--- a/frontend/src/stores/db.ts
+++ b/frontend/src/stores/db.ts
@@ -1,6 +1,6 @@
 import Dexie, { type EntityTable } from 'dexie';
 import type { SRSCard, UserProgress, VocabEntry } from '../types';
-import { curriculum } from '../data/curriculum';
+import { loadAllLessons } from '../data/lessonLoader';
 
 export const db = new Dexie('italearn') as Dexie & {
   srsCards: EntityTable<SRSCard, 'id'>;
@@ -33,25 +33,22 @@ db.version(3).stores({
  * Safe to call multiple times — skips words that already exist.
  */
 export async function seedVocabulary(): Promise<void> {
+  const lessons = await loadAllLessons();
   const entries: VocabEntry[] = [];
   const seen = new Set<string>();
 
-  for (const section of curriculum.sections) {
-    for (const unit of section.units) {
-      for (const lesson of unit.lessons) {
-        if (!lesson.vocabulary) continue;
-        for (const v of lesson.vocabulary) {
-          if (seen.has(v.word)) continue;
-          seen.add(v.word);
-          entries.push({
-            id: v.word,
-            word: v.word,
-            meaning: v.meaning,
-            example: v.example,
-            unit_id: unit.id,
-          });
-        }
-      }
+  for (const lesson of lessons) {
+    if (!lesson.vocabulary) continue;
+    for (const v of lesson.vocabulary) {
+      if (seen.has(v.word)) continue;
+      seen.add(v.word);
+      entries.push({
+        id: v.word,
+        word: v.word,
+        meaning: v.meaning,
+        example: v.example,
+        unit_id: lesson.unit_id,
+      });
     }
   }
 

--- a/frontend/src/types/curriculum.ts
+++ b/frontend/src/types/curriculum.ts
@@ -13,6 +13,14 @@ export interface Section {
   units: Unit[];
 }
 
+/** Lightweight lesson metadata kept inline in the curriculum (no exercises/vocabulary). */
+export interface LessonMeta {
+  id: string;
+  unit_id: string;
+  name: string;
+  order: number;
+}
+
 export interface Unit {
   id: string;
   section_id: string;
@@ -20,7 +28,7 @@ export interface Unit {
   grammar_focus: string;
   vocabulary_targets: string[];
   grammar_notes: string;
-  lessons: Lesson[];
+  lessons: LessonMeta[];
   order: number;
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -3,6 +3,7 @@ export type {
   Section,
   Unit,
   Lesson,
+  LessonMeta,
   LessonVocab,
   GrammarTip,
   Curriculum,


### PR DESCRIPTION
Curriculum now holds lightweight LessonMeta (id, name, order) instead of full Lesson objects. Lesson content (exercises, vocabulary, grammar tips) is loaded on demand when the user enters a lesson, producing separate Vite chunks per lesson file. seedVocabulary() and findLesson() are now async through the new lessonLoader module.

Closes #21