### PR TITLE
Add Section 1 checkpoint feature (#24)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import HydrationGuard from '@/shared/components/HydrationGuard'
 import PathPage from '@/features/path/PathPage'
 import LessonPage from '@/features/lesson/LessonPage'
 import ReviewPage from '@/features/review/ReviewPage'
+import CheckpointPage from '@/features/checkpoint/CheckpointPage'
 
 export default function App() {
   return (
@@ -12,6 +13,7 @@ export default function App() {
           <Route path="/" element={<PathPage />} />
           <Route path="/lesson/:id" element={<LessonPage />} />
           <Route path="/review" element={<ReviewPage />} />
+          <Route path="/checkpoint/:sectionId" element={<CheckpointPage />} />
         </Routes>
       </HydrationGuard>
     </BrowserRouter>

--- a/frontend/src/engine/checkpointRunner.ts
+++ b/frontend/src/engine/checkpointRunner.ts
@@ -1,0 +1,222 @@
+import type { Exercise, VocabEntry } from '../types';
+import { db } from '../stores/db';
+import { shuffle } from '../shared/utils/shuffle';
+
+const SECTION_1_UNITS = ['unit-01', 'unit-02', 'unit-03'];
+
+/** Map exercise id → unit_id for weak-area reporting */
+export type CheckpointExerciseMap = Map<string, string>;
+
+const TARGET_COUNT = 18;
+
+/** Hand-crafted exercises for essere/avere grammar — tagged as 'grammar' */
+const GRAMMAR_EXERCISES: Exercise[] = [
+  {
+    id: 'cp-grammar-01',
+    type: 'writing',
+    subtype: 'fill_blank',
+    prompt: { text: 'Fill in the correct form of essere.' },
+    sentence_context: 'Io ___ stanco.',
+    correct_answer: 'sono',
+    distractors: [],
+    hints: ['io → sono'],
+    target_words: ['essere'],
+  },
+  {
+    id: 'cp-grammar-02',
+    type: 'writing',
+    subtype: 'fill_blank',
+    prompt: { text: 'Fill in the correct form of essere.' },
+    sentence_context: 'Tu ___ italiano?',
+    correct_answer: 'sei',
+    distractors: [],
+    hints: ['tu → sei'],
+    target_words: ['essere'],
+  },
+  {
+    id: 'cp-grammar-03',
+    type: 'writing',
+    subtype: 'fill_blank',
+    prompt: { text: 'Fill in the correct form of essere.' },
+    sentence_context: 'Noi ___ studenti.',
+    correct_answer: 'siamo',
+    distractors: [],
+    hints: ['noi → siamo'],
+    target_words: ['essere'],
+  },
+  {
+    id: 'cp-grammar-04',
+    type: 'vocab',
+    subtype: 'multiple_choice',
+    prompt: { text: "Which form of essere means 'they are'?" },
+    sentence_context: 'Loro ___ amici.',
+    correct_answer: 'sono',
+    distractors: ['siamo', 'siete', 'è'],
+    hints: [],
+    target_words: ['essere'],
+  },
+  {
+    id: 'cp-grammar-05',
+    type: 'writing',
+    subtype: 'fill_blank',
+    prompt: { text: 'Fill in the correct form of avere.' },
+    sentence_context: 'Io ___ fame.',
+    correct_answer: 'ho',
+    distractors: [],
+    hints: ['io → ho'],
+    target_words: ['avere'],
+  },
+  {
+    id: 'cp-grammar-06',
+    type: 'writing',
+    subtype: 'fill_blank',
+    prompt: { text: 'Fill in the correct form of avere.' },
+    sentence_context: 'Tu ___ un cane?',
+    correct_answer: 'hai',
+    distractors: [],
+    hints: ['tu → hai'],
+    target_words: ['avere'],
+  },
+  {
+    id: 'cp-grammar-07',
+    type: 'vocab',
+    subtype: 'multiple_choice',
+    prompt: { text: "Which form of avere means 'we have'?" },
+    sentence_context: 'Noi ___ due gatti.',
+    correct_answer: 'abbiamo',
+    distractors: ['hanno', 'avete', 'ho'],
+    hints: [],
+    target_words: ['avere'],
+  },
+  {
+    id: 'cp-grammar-08',
+    type: 'writing',
+    subtype: 'fill_blank',
+    prompt: { text: 'Fill in the correct form of avere.' },
+    sentence_context: 'Loro ___ trent\'anni.',
+    correct_answer: 'hanno',
+    distractors: [],
+    hints: ['loro → hanno'],
+    target_words: ['avere'],
+  },
+];
+
+function buildTypeAnswer(entry: VocabEntry, idx: number): Exercise {
+  const meaning = entry.meaning.replace(/\s*\(.*?\)\s*/g, '').trim();
+  return {
+    id: `cp-vocab-${idx}-ta`,
+    type: 'vocab',
+    subtype: 'type_answer',
+    prompt: { text: `Translate to Italian: '${meaning}'` },
+    sentence_context: entry.example,
+    correct_answer: entry.word,
+    distractors: [],
+    hints: [],
+    target_words: [entry.id],
+  };
+}
+
+function buildMultipleChoice(
+  entry: VocabEntry,
+  idx: number,
+  pool: VocabEntry[],
+): Exercise {
+  const meaning = entry.meaning.replace(/\s*\(.*?\)\s*/g, '').trim();
+  const distractors = shuffle(pool.filter((v) => v.id !== entry.id))
+    .slice(0, 3)
+    .map((v) => v.meaning.replace(/\s*\(.*?\)\s*/g, '').trim());
+  return {
+    id: `cp-vocab-${idx}-mc`,
+    type: 'vocab',
+    subtype: 'multiple_choice',
+    prompt: { text: `What does '${entry.word}' mean?` },
+    sentence_context: entry.example,
+    correct_answer: meaning,
+    distractors,
+    hints: [],
+    target_words: [entry.id],
+  };
+}
+
+function buildCloze(entry: VocabEntry, idx: number): Exercise | null {
+  const pattern = new RegExp(
+    entry.word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+    'i',
+  );
+  if (!pattern.test(entry.example)) return null;
+  return {
+    id: `cp-vocab-${idx}-cloze`,
+    type: 'vocab',
+    subtype: 'cloze',
+    prompt: { text: 'Complete the sentence with the missing word.' },
+    sentence_context: entry.example.replace(pattern, '___'),
+    correct_answer: entry.word,
+    distractors: [],
+    hints: [entry.meaning.replace(/\s*\(.*?\)\s*/g, '').trim()],
+    target_words: [entry.id],
+  };
+}
+
+/**
+ * Build a mixed exercise set from Section 1 vocabulary + grammar.
+ * Returns exercises and a map from exercise id → unit_id (or 'grammar').
+ */
+export async function buildCheckpointExercises(): Promise<{
+  exercises: Exercise[];
+  unitMap: CheckpointExerciseMap;
+}> {
+  const vocab = await db.vocabulary
+    .filter((v) => SECTION_1_UNITS.includes(v.unit_id))
+    .toArray();
+
+  const pool = shuffle(vocab);
+
+  // Grammar exercises: pick 4 from the pool
+  const grammarSample = shuffle(GRAMMAR_EXERCISES).slice(0, 4);
+
+  // Vocab exercises: fill remaining slots (~14) from vocab pool
+  // Weight: 50% type_answer, 30% multiple_choice, 20% cloze
+  const vocabTarget = TARGET_COUNT - grammarSample.length;
+  const vocabSample = pool.slice(0, Math.min(vocabTarget, pool.length));
+
+  const vocabExercises: Exercise[] = [];
+  for (let i = 0; i < vocabSample.length; i++) {
+    const entry = vocabSample[i];
+    const roll = Math.random();
+    if (roll < 0.5) {
+      vocabExercises.push(buildTypeAnswer(entry, i));
+    } else if (roll < 0.8) {
+      vocabExercises.push(buildMultipleChoice(entry, i, pool));
+    } else {
+      const cloze = buildCloze(entry, i);
+      vocabExercises.push(cloze ?? buildTypeAnswer(entry, i));
+    }
+  }
+
+  const allExercises = shuffle([...grammarSample, ...vocabExercises]).slice(
+    0,
+    TARGET_COUNT,
+  );
+
+  // Build unit map for weak-area tracking
+  const unitMap: CheckpointExerciseMap = new Map();
+  for (const ex of grammarSample) {
+    unitMap.set(ex.id, 'grammar');
+  }
+  for (let i = 0; i < vocabSample.length; i++) {
+    const entry = vocabSample[i];
+    // Match exercise id suffix pattern to find the exercise
+    const possible = [
+      `cp-vocab-${i}-ta`,
+      `cp-vocab-${i}-mc`,
+      `cp-vocab-${i}-cloze`,
+    ];
+    for (const id of possible) {
+      if (allExercises.some((e) => e.id === id)) {
+        unitMap.set(id, entry.unit_id);
+      }
+    }
+  }
+
+  return { exercises: allExercises, unitMap };
+}

--- a/frontend/src/features/checkpoint/CheckpointPage.tsx
+++ b/frontend/src/features/checkpoint/CheckpointPage.tsx
@@ -1,0 +1,295 @@
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import ProgressBar from '@/shared/components/ProgressBar';
+import CloseIcon from '@/shared/components/CloseIcon';
+import renderExercise from '@/features/exercises/renderExercise';
+import { useCheckpointSession } from './useCheckpointSession';
+import type { CheckpointResult, AreaResult } from './useCheckpointSession';
+
+export default function CheckpointPage() {
+  const { sectionId } = useParams<{ sectionId: string }>();
+  const navigate = useNavigate();
+
+  const {
+    alreadyPassed,
+    started,
+    currentExercise,
+    currentIndex,
+    totalExercises,
+    checkpointResult,
+    handleStart,
+    handleExerciseComplete,
+  } = useCheckpointSession(sectionId ?? 'section-01');
+
+  if (!started && !checkpointResult) {
+    return (
+      <CheckpointIntro
+        alreadyPassed={alreadyPassed}
+        onStart={handleStart}
+        onBack={() => navigate('/')}
+      />
+    );
+  }
+
+  if (checkpointResult) {
+    return <CheckpointResults result={checkpointResult} />;
+  }
+
+  const progress = ((currentIndex + 1) / totalExercises) * 100;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="sticky top-0 bg-white border-b border-gray-200 px-4 py-3 z-10">
+        <div className="max-w-2xl mx-auto flex items-center gap-4">
+          <button
+            onClick={() => navigate('/')}
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+            aria-label="Exit checkpoint"
+          >
+            <CloseIcon />
+          </button>
+          <div className="flex-1">
+            <ProgressBar progress={progress} />
+          </div>
+          <span className="text-sm text-gray-500 whitespace-nowrap">
+            Question {currentIndex + 1}/{totalExercises}
+          </span>
+        </div>
+      </div>
+
+      <div className="max-w-2xl mx-auto p-6">
+        {currentExercise &&
+          renderExercise({
+            exercise: currentExercise,
+            onComplete: handleExerciseComplete,
+          })}
+      </div>
+    </div>
+  );
+}
+
+function CheckpointIntro({
+  alreadyPassed,
+  onStart,
+  onBack,
+}: {
+  alreadyPassed: boolean;
+  onStart: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <div className="max-w-md mx-auto mt-12 space-y-6">
+        <div className="text-center">
+          <div className="text-5xl mb-4">🏁</div>
+          <h1 className="text-3xl font-bold text-gray-900">
+            Section 1 Checkpoint
+          </h1>
+          <p className="text-gray-500 mt-2">First Steps</p>
+        </div>
+
+        {alreadyPassed && (
+          <div className="bg-green-50 border border-green-200 rounded-xl p-4 text-center">
+            <p className="text-green-700 font-medium">
+              ✓ You already passed this checkpoint!
+            </p>
+            <p className="text-green-600 text-sm mt-1">
+              Retake it for extra practice.
+            </p>
+          </div>
+        )}
+
+        <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
+          <div className="space-y-2 text-sm text-gray-600">
+            <div className="flex justify-between">
+              <span>Questions</span>
+              <span className="font-medium text-gray-900">~18</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Pass score</span>
+              <span className="font-medium text-gray-900">80%</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Covers</span>
+              <span className="font-medium text-gray-900">Units 1–3</span>
+            </div>
+          </div>
+          <hr className="border-gray-100" />
+          <p className="text-sm text-gray-500">
+            Tests vocabulary, greetings, essere, avere, numbers, and articles.
+            Pass to unlock Section 2.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <button
+            onClick={onStart}
+            autoFocus
+            className="w-full px-4 py-3 rounded-lg bg-blue-600 text-white font-medium hover:bg-blue-700 transition-colors"
+          >
+            {alreadyPassed ? 'Retake Checkpoint' : 'Start Checkpoint'}
+          </button>
+          <button
+            onClick={onBack}
+            className="w-full px-4 py-3 rounded-lg bg-gray-100 text-gray-700 font-medium hover:bg-gray-200 transition-colors"
+          >
+            Back to path
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CheckpointResults({ result }: { result: CheckpointResult }) {
+  const navigate = useNavigate();
+  const pct =
+    result.total > 0 ? Math.round((result.score / result.total) * 100) : 0;
+
+  const weakAreas = result.areas.filter(
+    (a) => a.total > 0 && a.correct / a.total < 0.7,
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <div className="max-w-md mx-auto mt-12 space-y-6">
+        <div className="text-center">
+          <div className="text-5xl mb-4">{result.passed ? '🎉' : '📚'}</div>
+          <h1 className="text-3xl font-bold text-gray-900">
+            {result.passed ? 'Checkpoint Passed!' : 'Not Quite Yet'}
+          </h1>
+        </div>
+
+        <div className="bg-white rounded-xl border border-gray-200 p-8 text-center space-y-2">
+          <p
+            className={`text-5xl font-bold ${result.passed ? 'text-green-600' : 'text-orange-500'}`}
+          >
+            {pct}%
+          </p>
+          <p className="text-gray-500">
+            {result.score}/{result.total} correct
+          </p>
+          {result.passed ? (
+            <p className="text-green-600 text-sm font-medium mt-2">
+              Section 2 unlocked!
+            </p>
+          ) : (
+            <p className="text-orange-500 text-sm font-medium mt-2">
+              Need 80% to pass
+            </p>
+          )}
+        </div>
+
+        {result.areas.length > 0 && (
+          <div className="bg-white rounded-xl border border-gray-200 p-5 space-y-3">
+            <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+              Breakdown
+            </h2>
+            {result.areas.map((area) => (
+              <AreaRow key={area.label} area={area} />
+            ))}
+          </div>
+        )}
+
+        {!result.passed && weakAreas.length > 0 && (
+          <div className="bg-orange-50 border border-orange-200 rounded-xl p-5 space-y-2">
+            <h2 className="text-sm font-semibold text-orange-800">
+              Areas to review:
+            </h2>
+            <ul className="text-sm text-orange-700 space-y-1">
+              {weakAreas.map((a) => (
+                <li key={a.label}>• {a.label}</li>
+              ))}
+            </ul>
+            <div className="pt-2 space-y-1">
+              {weakAreas
+                .filter((a) => a.label.startsWith('Unit 1'))
+                .map(() => (
+                  <Link
+                    key="unit-01"
+                    to="/lesson/unit-01-lesson-05"
+                    className="block text-sm text-blue-600 underline"
+                  >
+                    Review Unit 1 →
+                  </Link>
+                ))}
+              {weakAreas
+                .filter((a) => a.label.startsWith('Unit 2'))
+                .map(() => (
+                  <Link
+                    key="unit-02"
+                    to="/lesson/unit-02-lesson-08"
+                    className="block text-sm text-blue-600 underline"
+                  >
+                    Review Unit 2 →
+                  </Link>
+                ))}
+              {weakAreas
+                .filter((a) => a.label.startsWith('Unit 3'))
+                .map(() => (
+                  <Link
+                    key="unit-03"
+                    to="/lesson/unit-03-lesson-09"
+                    className="block text-sm text-blue-600 underline"
+                  >
+                    Review Unit 3 →
+                  </Link>
+                ))}
+              {weakAreas
+                .filter((a) => a.label.startsWith('Grammar'))
+                .map(() => (
+                  <Link
+                    key="grammar"
+                    to="/lesson/unit-02-lesson-08"
+                    className="block text-sm text-blue-600 underline"
+                  >
+                    Review Essere & Avere →
+                  </Link>
+                ))}
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {!result.passed && (
+            <Link
+              to="/checkpoint/section-01"
+              className="block w-full px-4 py-3 rounded-lg bg-blue-600 text-white font-medium text-center hover:bg-blue-700 transition-colors"
+            >
+              Try Again
+            </Link>
+          )}
+          <button
+            onClick={() => navigate('/')}
+            autoFocus={result.passed}
+            className="w-full px-4 py-3 rounded-lg bg-gray-100 text-gray-700 font-medium hover:bg-gray-200 transition-colors"
+          >
+            Back to path
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AreaRow({ area }: { area: AreaResult }) {
+  const pct = area.total > 0 ? Math.round((area.correct / area.total) * 100) : 0;
+  const isWeak = pct < 70;
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <span className="text-sm text-gray-600 flex-1">{area.label}</span>
+      <div className="flex items-center gap-2">
+        <div className="w-24 h-2 bg-gray-100 rounded-full overflow-hidden">
+          <div
+            className={`h-full rounded-full ${isWeak ? 'bg-orange-400' : 'bg-green-500'}`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <span
+          className={`text-sm font-medium w-10 text-right ${isWeak ? 'text-orange-600' : 'text-green-700'}`}
+        >
+          {pct}%
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/checkpoint/useCheckpointSession.ts
+++ b/frontend/src/features/checkpoint/useCheckpointSession.ts
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import type { Exercise, ExerciseResult } from '@/types';
+import { buildCheckpointExercises } from '@/engine/checkpointRunner';
+import type { CheckpointExerciseMap } from '@/engine/checkpointRunner';
+import { useProgressStore } from '@/stores/progressStore';
+
+const PASS_THRESHOLD = 0.8;
+
+export interface AreaResult {
+  label: string;
+  correct: number;
+  total: number;
+}
+
+export interface CheckpointResult {
+  score: number;
+  total: number;
+  passed: boolean;
+  areas: AreaResult[];
+}
+
+const AREA_LABELS: Record<string, string> = {
+  'unit-01': 'Unit 1: Greetings & Pronunciation',
+  'unit-02': 'Unit 2: Introductions & Essere',
+  'unit-03': 'Unit 3: Numbers & Avere',
+  grammar: 'Grammar: Essere & Avere',
+};
+
+export function useCheckpointSession(sectionId: string) {
+  const passCheckpoint = useProgressStore((s) => s.passCheckpoint);
+  const checkpointsPassed = useProgressStore((s) => s.checkpoints_passed);
+
+  const alreadyPassed = checkpointsPassed.includes(sectionId);
+
+  const [exercises, setExercises] = useState<Exercise[]>([]);
+  const [unitMap, setUnitMap] = useState<CheckpointExerciseMap>(new Map());
+  const [started, setStarted] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [results, setResults] = useState<ExerciseResult[]>([]);
+  const [checkpointResult, setCheckpointResult] =
+    useState<CheckpointResult | null>(null);
+
+  const currentExercise = exercises[currentIndex] ?? null;
+  const totalExercises = exercises.length;
+
+  async function handleStart() {
+    const built = await buildCheckpointExercises();
+    setExercises(built.exercises);
+    setUnitMap(built.unitMap);
+    setStarted(true);
+  }
+
+  async function handleExerciseComplete(er: ExerciseResult) {
+    const updated = [...results, er];
+    setResults(updated);
+
+    const nextIndex = currentIndex + 1;
+    if (nextIndex >= totalExercises) {
+      const finalResult = computeResult(updated, exercises, unitMap);
+      setCheckpointResult(finalResult);
+      if (finalResult.passed) {
+        await passCheckpoint(sectionId);
+      }
+    } else {
+      setCurrentIndex(nextIndex);
+    }
+  }
+
+  return {
+    alreadyPassed,
+    started,
+    currentExercise,
+    currentIndex,
+    totalExercises,
+    checkpointResult,
+    handleStart,
+    handleExerciseComplete,
+  };
+}
+
+function computeResult(
+  results: ExerciseResult[],
+  exercises: Exercise[],
+  unitMap: CheckpointExerciseMap,
+): CheckpointResult {
+  const score = results.filter((r) => r.correct).length;
+  const total = results.length;
+  const passed = total > 0 && score / total >= PASS_THRESHOLD;
+
+  // Tally per-area
+  const areaTotals = new Map<string, { correct: number; total: number }>();
+  for (const ex of exercises) {
+    const area = unitMap.get(ex.id) ?? 'other';
+    const result = results.find((r) => r.exercise_id === ex.id);
+    if (!result) continue;
+    const current = areaTotals.get(area) ?? { correct: 0, total: 0 };
+    areaTotals.set(area, {
+      correct: current.correct + (result.correct ? 1 : 0),
+      total: current.total + 1,
+    });
+  }
+
+  const areas: AreaResult[] = [...areaTotals.entries()].map(
+    ([key, counts]) => ({
+      label: AREA_LABELS[key] ?? key,
+      ...counts,
+    }),
+  );
+
+  return { score, total, passed, areas };
+}

--- a/frontend/src/features/path/PathPage.tsx
+++ b/frontend/src/features/path/PathPage.tsx
@@ -37,7 +37,11 @@ export default function Path() {
   const lessonsCompleted = useProgressStore((s) => s.lessons_completed);
   const lessonScores = useProgressStore((s) => s.lesson_scores);
   const resetLesson = useProgressStore((s) => s.resetLesson);
+  const checkpointsPassed = useProgressStore((s) => s.checkpoints_passed);
   const dueCount = useSrsStore((s) => s.reviewableCount);
+
+  const allSection1Complete = units.every((u) => isUnitComplete(u, lessonsCompleted));
+  const section1CheckpointPassed = checkpointsPassed.includes(section.id);
 
   const [expandedUnit, setExpandedUnit] = useState<string | null>(null);
 
@@ -89,6 +93,32 @@ export default function Path() {
               />
             );
           })}
+
+          {allSection1Complete && (
+            <Link
+              to={`/checkpoint/${section.id}`}
+              className={`flex items-center justify-between rounded-xl px-4 py-3 transition-colors border ${
+                section1CheckpointPassed
+                  ? 'bg-green-50 border-green-200 hover:bg-green-100'
+                  : 'bg-blue-600 border-transparent text-white hover:bg-blue-700'
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-lg">{section1CheckpointPassed ? '✓' : '🏁'}</span>
+                <div>
+                  <p className={`font-medium ${section1CheckpointPassed ? 'text-green-800' : ''}`}>
+                    Section 1 Checkpoint
+                  </p>
+                  <p className={`text-xs ${section1CheckpointPassed ? 'text-green-600' : 'text-blue-100'}`}>
+                    {section1CheckpointPassed ? 'Passed — retake anytime' : 'Unlock Section 2'}
+                  </p>
+                </div>
+              </div>
+              <span className={`text-sm font-medium ${section1CheckpointPassed ? 'text-green-700' : 'text-blue-100'}`}>
+                {section1CheckpointPassed ? 'Passed' : '≥ 80% to pass'}
+              </span>
+            </Link>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
- engine/checkpointRunner.ts: generates ~18 mixed exercises from Section 1 vocabulary (units 1-3) plus 4 hand-crafted essere/avere grammar exercises; returns a unitMap for per-area weak-spot reporting
- features/checkpoint/useCheckpointSession.ts: session state, 80% pass threshold, per-unit breakdown, persists pass via progressStore
- features/checkpoint/CheckpointPage.tsx: intro → exercise flow → results screen with score, pass/fail, weak-area breakdown and review links
- App.tsx: adds /checkpoint/:sectionId route inside HydrationGuard
- PathPage.tsx: shows checkpoint card (locked/passed states) after all Section 1 units are complete
Closes #24 