### PR TITLE
Add XP system & level progression (#34)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import HydrationGuard from '@/shared/components/HydrationGuard'
+import LevelUpToast from '@/shared/components/LevelUpToast'
 import PathPage from '@/features/path/PathPage'
 import LessonPage from '@/features/lesson/LessonPage'
 import ReviewPage from '@/features/review/ReviewPage'
@@ -9,6 +10,7 @@ export default function App() {
   return (
     <BrowserRouter>
       <HydrationGuard>
+        <LevelUpToast />
         <Routes>
           <Route path="/" element={<PathPage />} />
           <Route path="/lesson/:id" element={<LessonPage />} />

--- a/frontend/src/engine/xp.ts
+++ b/frontend/src/engine/xp.ts
@@ -1,0 +1,101 @@
+// ── XP Calculation ──────────────────────────────────────────────
+
+const LESSON_BASE_XP = 10;
+const REVIEW_BASE_XP = 8;
+const CHECKPOINT_BONUS_XP = 50;
+
+function streakMultiplier(streakCount: number): number {
+  if (streakCount >= 5) return 3;
+  if (streakCount >= 3) return 2;
+  return 1;
+}
+
+export function calculateExerciseXP(
+  correct: boolean,
+  streakCount: number,
+): number {
+  if (!correct) return 0;
+  return LESSON_BASE_XP * streakMultiplier(streakCount);
+}
+
+export function calculateReviewXP(
+  correct: boolean,
+  streakCount: number,
+): number {
+  if (!correct) return 0;
+  return REVIEW_BASE_XP * streakMultiplier(streakCount);
+}
+
+export function getCheckpointBonusXP(): number {
+  return CHECKPOINT_BONUS_XP;
+}
+
+// ── Level System ────────────────────────────────────────────────
+
+interface LevelThreshold {
+  level: number;
+  xp: number;
+}
+
+const LEVEL_THRESHOLDS: LevelThreshold[] = [
+  { level: 1, xp: 0 },
+  { level: 2, xp: 100 },
+  { level: 3, xp: 250 },
+  { level: 4, xp: 500 },
+  { level: 5, xp: 850 },
+  { level: 6, xp: 1300 },
+  { level: 7, xp: 1900 },
+  { level: 8, xp: 2600 },
+  { level: 9, xp: 3500 },
+  { level: 10, xp: 4600 },
+  { level: 11, xp: 5900 },
+  { level: 12, xp: 7500 },
+  { level: 13, xp: 9400 },
+  { level: 14, xp: 11600 },
+  { level: 15, xp: 14200 },
+  { level: 16, xp: 17200 },
+  { level: 17, xp: 20700 },
+  { level: 18, xp: 24700 },
+  { level: 19, xp: 29200 },
+  { level: 20, xp: 34500 },
+];
+
+const RANKS: { minLevel: number; name: string }[] = [
+  { minLevel: 1, name: 'Principiante' },
+  { minLevel: 5, name: 'Studente' },
+  { minLevel: 9, name: 'Intermedio' },
+  { minLevel: 13, name: 'Avanzato' },
+  { minLevel: 17, name: 'Esperto' },
+];
+
+export interface LevelInfo {
+  level: number;
+  rank: string;
+  currentXP: number;
+  currentThreshold: number;
+  nextThreshold: number;
+}
+
+export function getLevel(totalXP: number): LevelInfo {
+  let level = 1;
+  let currentThreshold = 0;
+
+  for (const t of LEVEL_THRESHOLDS) {
+    if (totalXP >= t.xp) {
+      level = t.level;
+      currentThreshold = t.xp;
+    } else {
+      break;
+    }
+  }
+
+  const nextEntry = LEVEL_THRESHOLDS.find((t) => t.level === level + 1);
+  const nextThreshold = nextEntry?.xp ?? currentThreshold;
+
+  let rank = RANKS[0].name;
+  for (const r of RANKS) {
+    if (level >= r.minLevel) rank = r.name;
+  }
+
+  return { level, rank, currentXP: totalXP, currentThreshold, nextThreshold };
+}

--- a/frontend/src/features/checkpoint/useCheckpointSession.ts
+++ b/frontend/src/features/checkpoint/useCheckpointSession.ts
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import type { Exercise, ExerciseResult } from '@/types';
 import { buildCheckpointExercises } from '@/engine/checkpointRunner';
 import type { CheckpointExerciseMap } from '@/engine/checkpointRunner';
 import { useProgressStore } from '@/stores/progressStore';
+import { calculateExerciseXP, getCheckpointBonusXP } from '@/engine/xp';
 
 const PASS_THRESHOLD = 0.8;
 
@@ -28,6 +29,7 @@ const AREA_LABELS: Record<string, string> = {
 
 export function useCheckpointSession(sectionId: string) {
   const passCheckpoint = useProgressStore((s) => s.passCheckpoint);
+  const addXP = useProgressStore((s) => s.addXP);
   const checkpointsPassed = useProgressStore((s) => s.checkpoints_passed);
 
   const alreadyPassed = checkpointsPassed.includes(sectionId);
@@ -39,6 +41,7 @@ export function useCheckpointSession(sectionId: string) {
   const [results, setResults] = useState<ExerciseResult[]>([]);
   const [checkpointResult, setCheckpointResult] =
     useState<CheckpointResult | null>(null);
+  const streakRef = useRef(0);
 
   const currentExercise = exercises[currentIndex] ?? null;
   const totalExercises = exercises.length;
@@ -51,6 +54,15 @@ export function useCheckpointSession(sectionId: string) {
   }
 
   async function handleExerciseComplete(er: ExerciseResult) {
+    // Track streak and award XP
+    if (er.correct) {
+      streakRef.current += 1;
+    } else {
+      streakRef.current = 0;
+    }
+    const xp = calculateExerciseXP(er.correct, streakRef.current);
+    if (xp > 0) addXP(xp);
+
     const updated = [...results, er];
     setResults(updated);
 
@@ -60,6 +72,7 @@ export function useCheckpointSession(sectionId: string) {
       setCheckpointResult(finalResult);
       if (finalResult.passed) {
         await passCheckpoint(sectionId);
+        await addXP(getCheckpointBonusXP());
       }
     } else {
       setCurrentIndex(nextIndex);

--- a/frontend/src/features/lesson/useLessonState.ts
+++ b/frontend/src/features/lesson/useLessonState.ts
@@ -1,6 +1,7 @@
-import { useState, useMemo } from 'react';
+import { useState, useRef, useMemo } from 'react';
 import type { Exercise, ExerciseResult, GrammarTip, Lesson, LessonResult } from '@/types';
 import { buildLessonResult } from '@/engine/lessonRunner';
+import { calculateExerciseXP } from '@/engine/xp';
 import { useProgressStore } from '@/stores/progressStore';
 import { useSrsStore } from '@/stores/srsStore';
 
@@ -53,6 +54,7 @@ function getInitialRetryExercises(
 export function useLessonState(lesson: Lesson) {
   const completeLesson = useProgressStore((s) => s.completeLesson);
   const saveLessonScore = useProgressStore((s) => s.saveLessonScore);
+  const addXP = useProgressStore((s) => s.addXP);
   const lessonScore = useProgressStore((s) => s.lesson_scores[lesson.id]);
   const addCards = useSrsStore((s) => s.addCards);
 
@@ -64,6 +66,7 @@ export function useLessonState(lesson: Lesson) {
   const [results, setResults] = useState<ExerciseResult[]>([]);
   const [lessonResult, setLessonResult] = useState<LessonResult | null>(null);
   const [startTime, setStartTime] = useState(() => Date.now());
+  const streakRef = useRef(0);
 
   const exercises = retryExercises ?? lesson.exercises;
   const isRetry = retryExercises !== null;
@@ -83,6 +86,15 @@ export function useLessonState(lesson: Lesson) {
   const progress = (exercisesDone / exerciseCount) * 100;
 
   function handleExerciseComplete(result: ExerciseResult) {
+    // Track streak and award XP
+    if (result.correct) {
+      streakRef.current += 1;
+    } else {
+      streakRef.current = 0;
+    }
+    const xp = calculateExerciseXP(result.correct, streakRef.current);
+    if (xp > 0) addXP(xp);
+
     const updatedResults = [...results, result];
     setResults(updatedResults);
     advanceOrComplete(currentIndex, updatedResults);
@@ -160,6 +172,7 @@ export function useLessonState(lesson: Lesson) {
     setCurrentIndex(0);
     setResults([]);
     setLessonResult(null);
+    streakRef.current = 0;
   }
 
   return {

--- a/frontend/src/features/review/useReviewSession.ts
+++ b/frontend/src/features/review/useReviewSession.ts
@@ -1,19 +1,23 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import type { ExerciseResult, ReviewResult, ReviewSession } from '@/types';
 import type { Grade } from 'ts-fsrs';
 import { useSrsStore } from '@/stores/srsStore';
+import { useProgressStore } from '@/stores/progressStore';
 import { buildReviewExercises, answerToGrade } from '@/engine/reviewRunner';
+import { calculateReviewXP } from '@/engine/xp';
 
 export function useReviewSession() {
   const dueCards = useSrsStore((s) => s.dueCards);
   const reviewableCount = useSrsStore((s) => s.reviewableCount);
   const reviewCard = useSrsStore((s) => s.reviewCard);
+  const addXP = useProgressStore((s) => s.addXP);
 
   const [session, setSession] = useState<ReviewSession | null>(null);
   const [started, setStarted] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [correctCount, setCorrectCount] = useState(0);
   const [result, setResult] = useState<ReviewResult | null>(null);
+  const streakRef = useRef(0);
 
   const currentExercise = session?.exercises[currentIndex] ?? null;
   const totalExercises = session?.exercises.length ?? reviewableCount;
@@ -38,6 +42,15 @@ export function useReviewSession() {
       const grade: Grade = answerToGrade(er.correct, er.time_spent_ms);
       await reviewCard(card.id, grade);
     }
+
+    // Track streak and award review XP
+    if (er.correct) {
+      streakRef.current += 1;
+    } else {
+      streakRef.current = 0;
+    }
+    const xp = calculateReviewXP(er.correct, streakRef.current);
+    if (xp > 0) addXP(xp);
 
     const newCorrect = correctCount + (er.correct ? 1 : 0);
     setCorrectCount(newCorrect);

--- a/frontend/src/shared/components/LevelUpToast.tsx
+++ b/frontend/src/shared/components/LevelUpToast.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useProgressStore } from '@/stores/progressStore';
+import { getLevel } from '@/engine/xp';
+
+export default function LevelUpToast() {
+  const previousLevel = useProgressStore((s) => s.previousLevel);
+  const xp = useProgressStore((s) => s.xp);
+  const clearLevelUp = useProgressStore((s) => s.clearLevelUp);
+
+  useEffect(() => {
+    if (previousLevel === null) return;
+    const timer = setTimeout(() => {
+      clearLevelUp();
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [previousLevel, clearLevelUp]);
+
+  if (previousLevel === null) return null;
+
+  const { level, rank } = getLevel(xp);
+
+  return (
+    <div className="fixed inset-x-0 top-6 z-50 flex justify-center pointer-events-none animate-bounce">
+      <div className="pointer-events-auto rounded-2xl bg-gradient-to-r from-amber-400 to-yellow-500 px-6 py-4 shadow-lg">
+        <div className="text-center">
+          <p className="text-sm font-medium text-amber-900">Level Up!</p>
+          <p className="text-2xl font-bold text-white">
+            Level {level} — {rank}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/stores/db.ts
+++ b/frontend/src/stores/db.ts
@@ -1,11 +1,12 @@
 import Dexie, { type EntityTable } from 'dexie';
-import type { SRSCard, UserProgress, VocabEntry } from '../types';
+import type { SRSCard, UserProgress, VocabEntry, XPLogEntry } from '../types';
 import { loadAllLessons } from '../data/lessonLoader';
 
 export const db = new Dexie('italearn') as Dexie & {
   srsCards: EntityTable<SRSCard, 'id'>;
   progress: EntityTable<UserProgress, 'id'>;
   vocabulary: EntityTable<VocabEntry, 'id'>;
+  xpLog: EntityTable<XPLogEntry, 'date'>;
 };
 
 db.version(1).stores({
@@ -26,6 +27,13 @@ db.version(3).stores({
   progress: '++id',
   lessonsCompleted: null,
   vocabulary: '&id, unit_id',
+});
+
+db.version(4).stores({
+  srsCards: '++id, [word_id+skill_type], due',
+  progress: '++id',
+  vocabulary: '&id, unit_id',
+  xpLog: '&date',
 });
 
 /**

--- a/frontend/src/stores/progressStore.ts
+++ b/frontend/src/stores/progressStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import type { UserProgress } from '../types';
 import { db } from './db';
+import { getLevel } from '../engine/xp';
 
 const DEFAULT_PROGRESS: UserProgress = {
   id: 1,
@@ -17,7 +18,11 @@ const DEFAULT_PROGRESS: UserProgress = {
 
 interface ProgressState extends UserProgress {
   hydrated: boolean;
+  /** Level before the most recent addXP call — null if no level-up occurred */
+  previousLevel: number | null;
   hydrate: () => Promise<void>;
+  addXP: (amount: number) => Promise<void>;
+  clearLevelUp: () => void;
   completeLesson: (lessonId: string) => Promise<void>;
   saveLessonScore: (lessonId: string, score: number, total: number, missedExerciseIds: string[]) => Promise<void>;
   resetLesson: (lessonId: string) => Promise<void>;
@@ -44,9 +49,14 @@ async function persist(state: ProgressState) {
   await db.progress.put(toData(state));
 }
 
+function todayDateString(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
 export const useProgressStore = create<ProgressState>()((set, get) => ({
   ...DEFAULT_PROGRESS,
   hydrated: false,
+  previousLevel: null,
 
   async hydrate() {
     const saved = await db.progress.get(1);
@@ -56,6 +66,31 @@ export const useProgressStore = create<ProgressState>()((set, get) => ({
       await db.progress.put({ ...DEFAULT_PROGRESS, id: 1 });
       set({ ...DEFAULT_PROGRESS, hydrated: true });
     }
+  },
+
+  async addXP(amount: number) {
+    if (amount <= 0) return;
+
+    const oldLevel = getLevel(get().xp).level;
+    const newXP = get().xp + amount;
+    const newLevelInfo = getLevel(newXP);
+
+    const leveledUp = newLevelInfo.level > oldLevel;
+    set({
+      xp: newXP,
+      level: newLevelInfo.level,
+      previousLevel: leveledUp ? oldLevel : null,
+    });
+    await persist(get());
+
+    // Update daily XP log
+    const today = todayDateString();
+    const existing = await db.xpLog.get(today);
+    await db.xpLog.put({ date: today, xp: (existing?.xp ?? 0) + amount });
+  },
+
+  clearLevelUp() {
+    set({ previousLevel: null });
   },
 
   async completeLesson(lessonId: string) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -26,4 +26,5 @@ export type {
   SRSCard,
   UserProgress,
   VocabEntry,
+  XPLogEntry,
 } from './progress';

--- a/frontend/src/types/progress.ts
+++ b/frontend/src/types/progress.ts
@@ -72,3 +72,11 @@ export interface UserProgress {
   /** Best score per lesson, keyed by lesson ID */
   lesson_scores: Record<string, LessonScore>;
 }
+
+/** Stored in Dexie — one row per day for daily XP tracking */
+export interface XPLogEntry {
+  /** ISO date string YYYY-MM-DD */
+  date: string;
+  /** Total XP earned on this date */
+  xp: number;
+}


### PR DESCRIPTION
Implement XP engine with streak multipliers, 20-level system with Italian rank names, daily XP logging, and level-up toast notification. Integrate XP awarding into lesson, review, and checkpoint flows.
Closes #34 