### PR TITLE
Streak tracking & calendar visualization (#35)

### DIFF
--- a/frontend/src/engine/streak.ts
+++ b/frontend/src/engine/streak.ts
@@ -1,0 +1,67 @@
+/** Streak calculation — operates on sorted arrays of ISO date strings (YYYY-MM-DD). */
+
+function toDateObj(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+function daysBetween(a: string, b: string): number {
+  const ms = toDateObj(b).getTime() - toDateObj(a).getTime();
+  return Math.round(ms / (1000 * 60 * 60 * 24));
+}
+
+export function todayDateString(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Consecutive days ending today (or yesterday).
+ * If the user hasn't been active today but was yesterday, the streak is still alive
+ * — it only breaks after a full missed day.
+ */
+export function getCurrentStreak(dates: string[]): number {
+  if (dates.length === 0) return 0;
+
+  const sorted = [...dates].sort();
+  const today = todayDateString();
+  const last = sorted[sorted.length - 1];
+
+  const gap = daysBetween(last, today);
+  // Streak is broken if last active day is more than 1 day ago
+  if (gap > 1) return 0;
+
+  let streak = 1;
+  for (let i = sorted.length - 2; i >= 0; i--) {
+    if (daysBetween(sorted[i], sorted[i + 1]) === 1) {
+      streak++;
+    } else {
+      break;
+    }
+  }
+  return streak;
+}
+
+/** Longest consecutive run of days in the history. */
+export function getLongestStreak(dates: string[]): number {
+  if (dates.length === 0) return 0;
+
+  const sorted = [...dates].sort();
+  let longest = 1;
+  let current = 1;
+
+  for (let i = 1; i < sorted.length; i++) {
+    if (daysBetween(sorted[i - 1], sorted[i]) === 1) {
+      current++;
+      if (current > longest) longest = current;
+    } else {
+      current = 1;
+    }
+  }
+
+  return longest;
+}
+
+/** Whether today is already counted as an active day. */
+export function isActiveToday(dates: string[]): boolean {
+  return dates.includes(todayDateString());
+}

--- a/frontend/src/features/lesson/useLessonState.ts
+++ b/frontend/src/features/lesson/useLessonState.ts
@@ -55,6 +55,7 @@ export function useLessonState(lesson: Lesson) {
   const completeLesson = useProgressStore((s) => s.completeLesson);
   const saveLessonScore = useProgressStore((s) => s.saveLessonScore);
   const addXP = useProgressStore((s) => s.addXP);
+  const logActivity = useProgressStore((s) => s.logActivity);
   const lessonScore = useProgressStore((s) => s.lesson_scores[lesson.id]);
   const addCards = useSrsStore((s) => s.addCards);
 
@@ -142,6 +143,7 @@ export function useLessonState(lesson: Lesson) {
 
     if (!isRetry) {
       await completeLesson(lesson.id);
+      await logActivity('lesson');
 
       const cardsToCreate: { wordId: string; skillType: 'vocab' | 'writing' }[] = [];
       for (const word of result.wordsEncountered) {

--- a/frontend/src/features/path/PathPage.tsx
+++ b/frontend/src/features/path/PathPage.tsx
@@ -5,6 +5,7 @@ import { useProgressStore } from '@/stores/progressStore';
 import { useSrsStore } from '@/stores/srsStore';
 import type { Unit, UnitStatus } from '@/types';
 import UnitCard from './UnitCard';
+import StreakCalendar from '@/shared/components/StreakCalendar';
 
 function getUnitStatus(
   unit: Unit,
@@ -52,6 +53,8 @@ export default function Path() {
         <p className="text-gray-500 mb-6">
           Section {section.order}: {section.name} — {section.cefr_level}
         </p>
+
+        <StreakCalendar />
 
         {dueCount > 0 && (
           <Link

--- a/frontend/src/features/review/useReviewSession.ts
+++ b/frontend/src/features/review/useReviewSession.ts
@@ -11,6 +11,7 @@ export function useReviewSession() {
   const reviewableCount = useSrsStore((s) => s.reviewableCount);
   const reviewCard = useSrsStore((s) => s.reviewCard);
   const addXP = useProgressStore((s) => s.addXP);
+  const logActivity = useProgressStore((s) => s.logActivity);
 
   const [session, setSession] = useState<ReviewSession | null>(null);
   const [started, setStarted] = useState(false);
@@ -42,6 +43,8 @@ export function useReviewSession() {
       const grade: Grade = answerToGrade(er.correct, er.time_spent_ms);
       await reviewCard(card.id, grade);
     }
+
+    await logActivity('review');
 
     // Track streak and award review XP
     if (er.correct) {

--- a/frontend/src/shared/components/StreakCalendar.tsx
+++ b/frontend/src/shared/components/StreakCalendar.tsx
@@ -1,0 +1,88 @@
+import { useMemo } from 'react';
+import { useProgressStore } from '@/stores/progressStore';
+import { getCurrentStreak, getLongestStreak, isActiveToday, todayDateString } from '@/engine/streak';
+
+function getLast30Days(): string[] {
+  const days: string[] = [];
+  const today = new Date();
+  for (let i = 29; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    days.push(d.toISOString().slice(0, 10));
+  }
+  return days;
+}
+
+const DAY_LABELS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+
+export default function StreakCalendar() {
+  const streakDates = useProgressStore((s) => s.streak_dates);
+
+  const days = useMemo(() => getLast30Days(), []);
+  const activeSet = useMemo(() => new Set(streakDates), [streakDates]);
+  const currentStreak = useMemo(() => getCurrentStreak(streakDates), [streakDates]);
+  const longestStreak = useMemo(() => getLongestStreak(streakDates), [streakDates]);
+  const activeToday = useMemo(() => isActiveToday(streakDates), [streakDates]);
+  const today = todayDateString();
+
+  return (
+    <div className="rounded-xl bg-white border border-gray-200 p-4 mb-6">
+      {/* Stats row */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <span className="text-2xl font-bold text-gray-900">{currentStreak}</span>
+          <span className="text-sm text-gray-500">day streak</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-gray-400">Best: {longestStreak}</span>
+          {activeToday && (
+            <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+              Active today
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Day-of-week headers — aligned to the grid's starting weekday */}
+      {(() => {
+        const firstDay = new Date(days[0] + 'T00:00:00');
+        // JS getDay: 0=Sun, convert to Mon-based: 0=Mon
+        const startDow = (firstDay.getDay() + 6) % 7;
+        const labels = [];
+        for (let i = 0; i < 7; i++) {
+          labels.push(DAY_LABELS[(startDow + i) % 7]);
+        }
+        return (
+          <div className="grid grid-cols-7 gap-1 mb-1">
+            {labels.map((label, i) => (
+              <div key={i} className="text-center text-[10px] text-gray-400">
+                {label}
+              </div>
+            ))}
+          </div>
+        );
+      })()}
+
+      {/* Calendar grid */}
+      <div className="grid grid-cols-7 gap-1">
+        {days.map((day) => {
+          const isActive = activeSet.has(day);
+          const isToday = day === today;
+          return (
+            <div
+              key={day}
+              className={`aspect-square rounded-md flex items-center justify-center text-[10px] font-medium ${
+                isActive
+                  ? 'bg-green-500 text-white'
+                  : 'bg-gray-100 text-gray-400'
+              } ${isToday ? 'ring-2 ring-offset-1 ring-gray-400' : ''}`}
+              title={day}
+            >
+              {new Date(day + 'T00:00:00').getDate()}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/stores/progressStore.ts
+++ b/frontend/src/stores/progressStore.ts
@@ -2,6 +2,9 @@ import { create } from 'zustand';
 import type { UserProgress } from '../types';
 import { db } from './db';
 import { getLevel } from '../engine/xp';
+import { getCurrentStreak } from '../engine/streak';
+
+const REVIEW_THRESHOLD = 5;
 
 const DEFAULT_PROGRESS: UserProgress = {
   id: 1,
@@ -14,6 +17,8 @@ const DEFAULT_PROGRESS: UserProgress = {
   lessons_completed: [],
   checkpoints_passed: [],
   lesson_scores: {},
+  streak_dates: [],
+  daily_activity: {},
 };
 
 interface ProgressState extends UserProgress {
@@ -28,6 +33,7 @@ interface ProgressState extends UserProgress {
   resetLesson: (lessonId: string) => Promise<void>;
   unlockUnit: (unitId: string) => Promise<void>;
   passCheckpoint: (sectionId: string) => Promise<void>;
+  logActivity: (type: 'lesson' | 'review') => Promise<void>;
 }
 
 function toData(state: ProgressState): UserProgress {
@@ -42,6 +48,8 @@ function toData(state: ProgressState): UserProgress {
     lessons_completed: state.lessons_completed,
     checkpoints_passed: state.checkpoints_passed,
     lesson_scores: state.lesson_scores,
+    streak_dates: state.streak_dates,
+    daily_activity: state.daily_activity,
   };
 }
 
@@ -61,7 +69,13 @@ export const useProgressStore = create<ProgressState>()((set, get) => ({
   async hydrate() {
     const saved = await db.progress.get(1);
     if (saved) {
-      set({ ...saved, lesson_scores: saved.lesson_scores ?? {}, hydrated: true });
+      set({
+        ...saved,
+        lesson_scores: saved.lesson_scores ?? {},
+        streak_dates: saved.streak_dates ?? [],
+        daily_activity: saved.daily_activity ?? {},
+        hydrated: true,
+      });
     } else {
       await db.progress.put({ ...DEFAULT_PROGRESS, id: 1 });
       set({ ...DEFAULT_PROGRESS, hydrated: true });
@@ -131,6 +145,34 @@ export const useProgressStore = create<ProgressState>()((set, get) => ({
 
     const updated = [...get().checkpoints_passed, sectionId];
     set({ checkpoints_passed: updated });
+    await persist(get());
+  },
+
+  async logActivity(type: 'lesson' | 'review') {
+    const today = todayDateString();
+    const activity = { ...get().daily_activity };
+    const todayActivity = activity[today] ?? { lessons: 0, reviews: 0 };
+
+    if (type === 'lesson') {
+      todayActivity.lessons += 1;
+    } else {
+      todayActivity.reviews += 1;
+    }
+    activity[today] = todayActivity;
+
+    const meetsThreshold =
+      todayActivity.lessons >= 1 || todayActivity.reviews >= REVIEW_THRESHOLD;
+
+    let streakDates = get().streak_dates;
+    if (meetsThreshold && !streakDates.includes(today)) {
+      streakDates = [...streakDates, today];
+    }
+
+    set({
+      daily_activity: activity,
+      streak_dates: streakDates,
+      streak: getCurrentStreak(streakDates),
+    });
     await persist(get());
   },
 }));

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -18,6 +18,7 @@ export type {
 } from './exercise';
 
 export type {
+  DailyActivity,
   ExerciseResult,
   LessonResult,
   LessonScore,

--- a/frontend/src/types/progress.ts
+++ b/frontend/src/types/progress.ts
@@ -71,6 +71,16 @@ export interface UserProgress {
   checkpoints_passed: string[];
   /** Best score per lesson, keyed by lesson ID */
   lesson_scores: Record<string, LessonScore>;
+  /** ISO date strings (YYYY-MM-DD) of days the user was active */
+  streak_dates: string[];
+  /** Daily activity counts, keyed by ISO date string */
+  daily_activity: Record<string, DailyActivity>;
+}
+
+/** Daily activity counters for streak threshold evaluation */
+export interface DailyActivity {
+  lessons: number;
+  reviews: number;
 }
 
 /** Stored in Dexie — one row per day for daily XP tracking */


### PR DESCRIPTION
- Add streak engine (getCurrentStreak, getLongestStreak, isActiveToday)
- Add streakDates, dailyActivity, and logActivity() to progressStore
- Log activity on lesson completion and each review exercise
- A day counts as active with ≥1 lesson or ≥5 reviews
- Create StreakCalendar component (30-day grid, current/longest streak)
- Add StreakCalendar to PathPage 

Closes #35